### PR TITLE
Update to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ${{ github.token }}
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'shield'


### PR DESCRIPTION
Hi,

GitHub enforces upgrading to Node20 (see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) and using Node16 causes warnings in our actions.

I don't know, if there is anything else to do except replacing that version.